### PR TITLE
include baseUrl to fix menu urls

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,6 +8,8 @@ var Root = require('../src/root.jsx');
 var props = require('jxnblk-api');
 
 props.title = 'Jxnblk';
+props.baseUrl = "";
+
 props.description = 'Brent Jackson';
 props.stylesheet = 'http://d2v52k3cl9vedd.cloudfront.net/blk/1.0.1/blk.min.css';
 


### PR DESCRIPTION
Hey, your projects are rad and I noticed your social links were broken on http://jxnblk.com/ because `props.baseUrl` is undefined.

TIL about react-static because of your site. 

Thank you!
